### PR TITLE
added actionIncludes on Cards.ForList request

### DIFF
--- a/TrelloNet/Cards/Card.cs
+++ b/TrelloNet/Cards/Card.cs
@@ -20,6 +20,7 @@ namespace TrelloNet
         public CardBadges Badges { get; set; }
         public List<Checklist> Checklists { get; set; }
         public List<Attachment> Attachments { get; set; }
+        public List<Action> Actions { get; set; }
         public string Url { get; set; }
         public double Pos { get; set; }
 

--- a/TrelloNet/Cards/IAsyncCards.cs
+++ b/TrelloNet/Cards/IAsyncCards.cs
@@ -32,7 +32,7 @@ namespace TrelloNet
 		/// <br/>
 		/// Required permissions: read
 		/// </summary>
-		Task<IEnumerable<Card>> ForList(IListId list, CardFilter filter = CardFilter.Open);
+        Task<IEnumerable<Card>> ForList(IListId list, CardFilter filter = CardFilter.Open, IEnumerable<ActionType> actionIncludes = null);
 
 		/// <summary>
 		/// GET /members/[member_id or username]/cards

--- a/TrelloNet/Cards/ICards.cs
+++ b/TrelloNet/Cards/ICards.cs
@@ -33,7 +33,7 @@ namespace TrelloNet
 		/// <br/>
 		/// Required permissions: read
 		/// </summary>
-		IEnumerable<Card> ForList(IListId list, CardFilter filter = CardFilter.Open);
+        IEnumerable<Card> ForList(IListId list, CardFilter filter = CardFilter.Open, IEnumerable<ActionType> actionIncludes = null);
 
 		/// <summary>
 		/// GET /members/[member_id or username]/cards

--- a/TrelloNet/Cards/Internal/AsyncCards.cs
+++ b/TrelloNet/Cards/Internal/AsyncCards.cs
@@ -28,9 +28,9 @@ namespace TrelloNet.Internal
 			return _restClient.RequestListAsync<Card>(new CardsForBoardRequest(board, filter));
 		}
 
-		public Task<IEnumerable<Card>> ForList(IListId list, CardFilter filter = CardFilter.Open)
+        public Task<IEnumerable<Card>> ForList(IListId list, CardFilter filter = CardFilter.Open, IEnumerable<ActionType> actionIncludes = null)
 		{
-			return _restClient.RequestListAsync<Card>(new CardsForListRequest(list, filter));
+            return _restClient.RequestListAsync<Card>(new CardsForListRequest(list, filter, actionIncludes));
 		}
 
 		public Task<IEnumerable<Card>> ForMember(IMemberId member, CardFilter filter = CardFilter.Open)

--- a/TrelloNet/Cards/Internal/Cards.cs
+++ b/TrelloNet/Cards/Internal/Cards.cs
@@ -27,9 +27,9 @@ namespace TrelloNet.Internal
 			return _restClient.Request<List<Card>>(new CardsForBoardRequest(board, filter));
 		}
 
-		public IEnumerable<Card> ForList(IListId list, CardFilter filter = CardFilter.Open)
+		public IEnumerable<Card> ForList(IListId list, CardFilter filter = CardFilter.Open, IEnumerable<ActionType> actionIncludes = null)
 		{
-			return _restClient.Request<List<Card>>(new CardsForListRequest(list, filter));
+            return _restClient.Request<List<Card>>(new CardsForListRequest(list, filter, actionIncludes));
 		}
 
 		public IEnumerable<Card> ForMember(IMemberId member, CardFilter filter = CardFilter.Open)

--- a/TrelloNet/Cards/Internal/CardsForListRequest.cs
+++ b/TrelloNet/Cards/Internal/CardsForListRequest.cs
@@ -1,12 +1,15 @@
+using System.Collections.Generic;
 namespace TrelloNet.Internal
 {
 	internal class CardsForListRequest : ListsRequest
 	{
-		public CardsForListRequest(IListId list, CardFilter filter)
+        public CardsForListRequest(IListId list, CardFilter filter, IEnumerable<ActionType> includeActions = null)
 			: base(list, "cards")
 		{
 			this.AddCommonCardParameters();
 			this.AddFilter(filter);
+            this.AddTypeInclude(includeActions);
+            
 		}
 	}
 }

--- a/TrelloNet/Internal/RestRequestExtensions.cs
+++ b/TrelloNet/Internal/RestRequestExtensions.cs
@@ -60,5 +60,15 @@ namespace TrelloNet.Internal
 
 			request.AddParameter("filter", filterString, ParameterType.GetOrPost);
 		}
+
+        public static void AddTypeInclude(this RestRequest request, IEnumerable<ActionType> actionIncludes)
+        {
+            var includeString = "all";
+
+            if (actionIncludes != null && actionIncludes.Any())
+                includeString = string.Join(",", actionIncludes.Select(f => f.ToTrelloString()));
+
+            request.AddParameter("actions", includeString, ParameterType.GetOrPost);
+        }
 	}
 }


### PR DESCRIPTION
This pull request added the ability to add the "actions" parameter to the lists/{id}/cards request. https://trello.com/docs/api/list/index.html#get-1-lists-idlist-cards-filter

I modeled the extra parameter after how you did the action filters. 

**Purpose:** I did this so you can query all the cards for a list including it's actions to avoid having to loop for every card and make another API call. 
