### PR TITLE
adding Observers commenting permission

### DIFF
--- a/TrelloNet/Boards/CommentPermission.cs
+++ b/TrelloNet/Boards/CommentPermission.cs
@@ -9,7 +9,8 @@ namespace TrelloNet
 		Unknown = 0,
 		Disabled,
 		Members,
+		Observers,
 		Org,
-		Public		
+		Public
 	}
 }


### PR DESCRIPTION
We have a business class Trello account so I believe this permission is normally not available.  Quick change, but I did re-order the Enums on purpose from most restrictive to least.
