### PR TITLE
added redirectUri parameter to GetAuthorizationUrl

### DIFF
--- a/TrelloNet/ITrello.cs
+++ b/TrelloNet/ITrello.cs
@@ -21,5 +21,6 @@ namespace TrelloNet
 		void Authorize(string token);
 		void Deauthorize();
 		Uri GetAuthorizationUrl(string applicationName, Scope scope, Expiration expiration = Expiration.ThirtyDays);
+		Uri GetAuthorizationUrl(string applicationName, Scope scope, Uri redirectUri, Expiration expiration = Expiration.ThirtyDays);
 	}
 }

--- a/TrelloNet/Internal/TrelloRestClient.cs
+++ b/TrelloNet/Internal/TrelloRestClient.cs
@@ -33,6 +33,14 @@ namespace TrelloNet.Internal
 				BaseUrl, _applicationKey, applicationName, scope.ToScopeString(), expiration.ToExpirationString()));
 		}
 
+		public Uri GetAuthorizationUrl(string applicationName, Scope scope, Expiration expiration, Uri redirectUri)
+		{
+			Guard.NotNullOrEmpty(applicationName, "applicationName");
+
+			return new Uri(string.Format("{0}/authorize?key={1}&name={2}&scope={3}&expiration={4}&callback_method=fragment&return_url={5}",
+				BaseUrl, _applicationKey, applicationName, scope.ToScopeString(), expiration.ToExpirationString(), Uri.EscapeUriString(redirectUri.ToString())));
+		}
+
 		public void Request(IRestRequest request)
 		{
 			var response = Execute(request);

--- a/TrelloNet/Trello.cs
+++ b/TrelloNet/Trello.cs
@@ -58,5 +58,10 @@ namespace TrelloNet
 		{
 			return _restClient.GetAuthorizationUrl(applicationName, scope, expiration);
 		}
+
+		public Uri GetAuthorizationUrl(string applicationName, Scope scope, Uri redirectUri, Expiration expiration = Expiration.ThirtyDays)
+		{
+			return _restClient.GetAuthorizationUrl(applicationName, scope, expiration, redirectUri);
+		}
 	}
 }


### PR DESCRIPTION
By specifying the `return_url` parameter to `/authorize`, the user will automatically be redirected back to the calling web application after authorizing access.

Instead of creating an overloaded method for this, I thought about including `redirectUri` as an optional parameter, but in the original implementation of `GetAuthorizationUrl`, you're using `/connect` instead of `/authorize`, but I couldn't find any documentation on `/connect`. Perhaps this is an old endpoint that is only left open for backwards compatibility?
