### PR TITLE
Any label color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.nupkg
 packages/
+TrelloNet.sln.ide

--- a/TrelloNet.Tests/BoardTests.cs
+++ b/TrelloNet.Tests/BoardTests.cs
@@ -372,7 +372,7 @@ namespace TrelloNet.Tests
 				Name = "Welcome Board",
 				Desc = "A test description",
 				IdOrganization = Constants.TestOrganizationId,
-				Pinned = true,
+				Pinned = false,
 				Url = "https://trello.com/b/J9JUdoYV/welcome-board",
 				Id = Constants.WelcomeBoardId,
 				Prefs = new BoardPreferences
@@ -395,6 +395,10 @@ namespace TrelloNet.Tests
 					{ Color.Orange, "" },
 					{ Color.Green, "label name" },
 					{ Color.Blue, "" },
+					{ Color.Pink, "" },
+					{ Color.Sky, "" },
+					{ Color.Lime, "" },
+					{ Color.Black, "" },
 				};
 		}
 	}

--- a/TrelloNet.Tests/SearchTests.cs
+++ b/TrelloNet.Tests/SearchTests.cs
@@ -50,7 +50,7 @@ namespace TrelloNet.Tests
                 Name = "Welcome Board",
                 Desc = "A test description",
                 IdOrganization = Constants.TestOrganizationId,
-                Pinned = true,
+                Pinned = false,
                 Url = "https://trello.com/b/J9JUdoYV/welcome-board",
                 Id = Constants.WelcomeBoardId,
                 Prefs = new BoardPreferences
@@ -62,12 +62,16 @@ namespace TrelloNet.Tests
                 },
                 LabelNames = new Dictionary<Color, string>
 				{
+					{ Color.Green, "label name" },
 					{ Color.Yellow, "" },
+					{ Color.Orange, "" },
 					{ Color.Red, "" },
 					{ Color.Purple, "" },
-					{ Color.Orange, "" },
-					{ Color.Green, "label name" },
 					{ Color.Blue, "" },
+					{ Color.Pink, "" },
+					{ Color.Sky, "" },
+					{ Color.Lime, "" },
+					{ Color.Black, "" },
 				}
             }.ToExpectedObject();
 

--- a/TrelloNet/Boards/Internal/BoardsChangeLabelNameRequest.cs
+++ b/TrelloNet/Boards/Internal/BoardsChangeLabelNameRequest.cs
@@ -7,7 +7,7 @@ namespace TrelloNet.Internal
 		public BoardsChangeLabelNameRequest(IBoardId board, Color color, string name)
 			: base(board, "labelNames/{color}", Method.PUT)
 		{
-			AddParameter("color", color.ToTrelloString(), ParameterType.UrlSegment);
+			AddParameter("color", color.ColorName, ParameterType.UrlSegment);
 			this.AddValue(name ?? "");
 		}
 	}

--- a/TrelloNet/Boards/Internal/BoardsChangeLabelNameRequest.cs
+++ b/TrelloNet/Boards/Internal/BoardsChangeLabelNameRequest.cs
@@ -7,6 +7,8 @@ namespace TrelloNet.Internal
 		public BoardsChangeLabelNameRequest(IBoardId board, Color color, string name)
 			: base(board, "labelNames/{color}", Method.PUT)
 		{
+			Guard.NotNull(color, "color");
+
 			AddParameter("color", color.ColorName, ParameterType.UrlSegment);
 			this.AddValue(name ?? "");
 		}

--- a/TrelloNet/Boards/Internal/ColorConverter.cs
+++ b/TrelloNet/Boards/Internal/ColorConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace TrelloNet.Internal
+{
+	internal class ColorConverter : TypeConverter
+	{
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+		{
+			return sourceType == typeof (string);
+		}
+
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			if (value == null) return null;
+
+			var colorName = value as string;
+			if (colorName != null)
+			{
+				return new Color(colorName);
+			}
+			else
+			{
+				throw new NotSupportedException(
+					string.Format(
+						"Conversion from {0} to Color is not supported",
+						value.GetType().Name));
+			}
+		}
+	}
+}

--- a/TrelloNet/Boards/Internal/ColorConverter.cs
+++ b/TrelloNet/Boards/Internal/ColorConverter.cs
@@ -13,6 +13,7 @@ namespace TrelloNet.Internal
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
+			// color can be null in uncolored label attached to a card.
 			if (value == null) return null;
 
 			var colorName = value as string;

--- a/TrelloNet/Cards/Card.cs
+++ b/TrelloNet/Cards/Card.cs
@@ -25,7 +25,7 @@ namespace TrelloNet
         public double Pos { get; set; }
         public DateTime DateLastActivity { get; set; }
         public List<string> IdMembers { get; set; }
-        public IEnumerable<Color> LabelColors { get { return Labels == null ? Enumerable.Empty<Color>() : Labels.Select(l => l.Color); } }
+        public IEnumerable<Color> LabelColors { get { return Labels == null ? Enumerable.Empty<Color>() : Labels.Where(l => l.Color != null).Select(l => l.Color); } }
 
         public string GetCardId()
         {

--- a/TrelloNet/Cards/Color.cs
+++ b/TrelloNet/Cards/Color.cs
@@ -1,16 +1,63 @@
+using System;
+using System.ComponentModel;
+using TrelloNet.Internal;
+
 namespace TrelloNet
 {
-	public enum Color
+	[TypeConverter(typeof(ColorConverter))]
+	public class Color
 	{
-		Green,
-		Yellow,
-		Orange,
-		Red,
-		Purple,
-		Blue,
-		Pink,
-		Sky,
-		Lime,
-		Black
+		public static readonly Color Green = new Color("green");
+		public static readonly Color Yellow = new Color("yellow");
+		public static readonly Color Orange = new Color("orange");
+		public static readonly Color Red = new Color("red");
+		public static readonly Color Purple = new Color("purple");
+		public static readonly Color Blue = new Color("blue");
+		public static readonly Color Pink = new Color("pink");
+		public static readonly Color Sky = new Color("sky");
+		public static readonly Color Lime = new Color("lime");
+		public static readonly Color Black = new Color("black");
+
+		public string ColorName { get; private set; }
+
+		public Color(string colorName)
+		{
+			if (colorName == null) throw new ArgumentNullException("colorName");
+
+			ColorName = colorName.ToLower();
+		}
+
+		public override string ToString()
+		{
+			return ColorName;
+		}
+
+		protected bool Equals(Color other)
+		{
+			return string.Equals(ColorName, other.ColorName);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != GetType()) return false;
+			return Equals((Color)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return (ColorName != null ? ColorName.GetHashCode() : 0);
+		}
+
+		public static bool operator ==(Color left, Color right)
+		{
+			return Equals(left, right);
+		}
+
+		public static bool operator !=(Color left, Color right)
+		{
+			return !Equals(left, right);
+		}
 	}
 }

--- a/TrelloNet/Cards/Color.cs
+++ b/TrelloNet/Cards/Color.cs
@@ -7,6 +7,7 @@ namespace TrelloNet
 	[TypeConverter(typeof(ColorConverter))]
 	public class Color
 	{
+		// Known colors:
 		public static readonly Color Green = new Color("green");
 		public static readonly Color Yellow = new Color("yellow");
 		public static readonly Color Orange = new Color("orange");

--- a/TrelloNet/Cards/Color.cs
+++ b/TrelloNet/Cards/Color.cs
@@ -7,6 +7,10 @@ namespace TrelloNet
 		Orange,
 		Red,
 		Purple,
-		Blue
+		Blue,
+		Pink,
+		Sky,
+		Lime,
+		Black
 	}
 }

--- a/TrelloNet/Cards/Internal/CardsAddLabelRequest.cs
+++ b/TrelloNet/Cards/Internal/CardsAddLabelRequest.cs
@@ -7,6 +7,8 @@ namespace TrelloNet.Internal
 		public CardsAddLabelRequest(ICardId card, Color color)
 			: base(card, "labels", Method.POST)
 		{
+			Guard.NotNull(color, "color");
+
 			this.AddValue(color.ColorName);
 		}
 	}

--- a/TrelloNet/Cards/Internal/CardsAddLabelRequest.cs
+++ b/TrelloNet/Cards/Internal/CardsAddLabelRequest.cs
@@ -7,7 +7,7 @@ namespace TrelloNet.Internal
 		public CardsAddLabelRequest(ICardId card, Color color)
 			: base(card, "labels", Method.POST)
 		{
-			this.AddValue(color.ToTrelloString());
+			this.AddValue(color.ColorName);
 		}
 	}
 }

--- a/TrelloNet/Cards/Internal/CardsRemoveLabelRequest.cs
+++ b/TrelloNet/Cards/Internal/CardsRemoveLabelRequest.cs
@@ -7,6 +7,8 @@ namespace TrelloNet.Internal
 		public CardsRemoveLabelRequest(ICardId card, Color color)
 			: base(card, "labels/{color}", Method.DELETE)
 		{
+			Guard.NotNull(color, "color");
+
 			AddParameter("color", color.ColorName, ParameterType.UrlSegment);
 		}
 	}

--- a/TrelloNet/Cards/Internal/CardsRemoveLabelRequest.cs
+++ b/TrelloNet/Cards/Internal/CardsRemoveLabelRequest.cs
@@ -7,7 +7,7 @@ namespace TrelloNet.Internal
 		public CardsRemoveLabelRequest(ICardId card, Color color)
 			: base(card, "labels/{color}", Method.DELETE)
 		{
-			AddParameter("color", color.ToTrelloString(), ParameterType.UrlSegment);
+			AddParameter("color", color.ColorName, ParameterType.UrlSegment);
 		}
 	}
 }

--- a/TrelloNet/Cards/Internal/CardsUpdateRequest.cs
+++ b/TrelloNet/Cards/Internal/CardsUpdateRequest.cs
@@ -19,7 +19,7 @@ namespace TrelloNet.Internal
 			AddParameter("closed", card.Closed.ToTrelloString());
 			AddParameter("idList", card.IdList);
 			AddParameter("due", card.Due == null ? null : new DateTimeOffset(card.Due.Value).ToString(CultureInfo.InvariantCulture));
-            AddParameter("labels", string.Join(",", card.LabelColors.Select(c => c.ToTrelloString())));
+            AddParameter("labels", string.Join(",", card.LabelColors.Select(c => c.ColorName)));
 		}
 	}
 }

--- a/TrelloNet/TrelloNet.csproj
+++ b/TrelloNet/TrelloNet.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Boards\Internal\BoardsRemoveMemberRequest.cs" />
     <Compile Include="Boards\Internal\BoardsUpdateRequest.cs" />
     <Compile Include="Boards\Internal\BoardsWithIdRequest.cs" />
+    <Compile Include="Boards\Internal\ColorConverter.cs" />
     <Compile Include="Boards\IUpdatableBoard.cs" />
     <Compile Include="Cards\BoardCardFilter.cs" />
     <Compile Include="CardName.cs" />


### PR DESCRIPTION
A while ago new colors for labels were introduced as discussed here: https://github.com/dillenmeister/Trello.NET/issues/57. Potentially this is also a root cause of https://github.com/dillenmeister/Trello.NET/issues/53. Moreover, now unlimited number of uncolored labels can be attached to a card. JSON response for this card looks like:

```
"labels":[
 {
    "id":"54720d01bafdf2374fc135d1",
    "idBoard":"50d6b44e8fab449f7800531f",
    "name":"some uncolored label",
    "color":null,
    "uses":1
 }]
```

I replaced `Color` enumeration with a class, so now any new color doesn't break an application and cards with uncolored labels can be deserialized.
