### PR TITLE
Add missing colours

### DIFF
--- a/TrelloNet.Tests/SearchTests.cs
+++ b/TrelloNet.Tests/SearchTests.cs
@@ -62,12 +62,16 @@ namespace TrelloNet.Tests
                 },
                 LabelNames = new Dictionary<Color, string>
 				{
+					{ Color.Green, "" },
 					{ Color.Yellow, "" },
+					{ Color.Orange, "" },
 					{ Color.Red, "" },
 					{ Color.Purple, "" },
-					{ Color.Orange, "" },
-					{ Color.Green, "label name" },
 					{ Color.Blue, "" },
+					{ Color.Sky, "" },
+					{ Color.Lime, "" },
+					{ Color.Pink, "" },
+					{ Color.Black, "" }
 				}
             }.ToExpectedObject();
 

--- a/TrelloNet/Cards/Color.cs
+++ b/TrelloNet/Cards/Color.cs
@@ -7,6 +7,10 @@ namespace TrelloNet
 		Orange,
 		Red,
 		Purple,
-		Blue
+		Blue,
+		Sky,
+	        Lime,
+	        Pink,
+	        Black
 	}
 }


### PR DESCRIPTION
Sky, Lime, Pink and Black were missing cause the cast to fail when mapping the raw request back to the Card object
